### PR TITLE
fix(android): issue the prop onRequestClose is marked as required in Modal, bu…

### DIFF
--- a/src/list.js
+++ b/src/list.js
@@ -38,7 +38,9 @@ class List extends Component {
 
     return (
       <Modal
-        transparent={true}>
+        transparent={true}
+        onRequestClose={() => { }}
+      >
         <TouchableWithoutFeedback onPress={this.props.onOverlayPress}>
           <View style={{ flex: 1}}></View>
         </TouchableWithoutFeedback>


### PR DESCRIPTION
Fix: Warning: Failed prop type: The prop `onRequestClose` is marked as required in `Modal`, but its value is `undefined`.
    in Modal (at list.js:40)
    in List (at select.js:91)